### PR TITLE
Add CSS styles for map viewport pan/zoom support

### DIFF
--- a/assets/css/zelda-botw.css
+++ b/assets/css/zelda-botw.css
@@ -696,6 +696,19 @@ button.no-text.with-icon:before{margin-right:0px}
 	position: relative;
 }
 
+/* Map viewport for pan/zoom */
+#map-viewport {
+	width: 100%;
+	height: calc(100vh - 180px);
+	overflow: hidden;
+	position: relative;
+	background: #0a0606;
+}
+
+#map-viewport #map-container {
+	transform-origin: 0 0;
+}
+
 #path-svg {
 	width: 6000px !important;
 	height: 5000px !important;


### PR DESCRIPTION
## Summary

- Added CSS styles to support the map pan/zoom feature introduced in a previous commit

## Changes

### `assets/css/zelda-botw.css`
- **`#map-viewport`** — constrains the map area to full viewport height minus the toolbar (180px), hides overflow, and applies a dark background (`#0a0606`)
- **`#map-viewport #map-container`** — sets `transform-origin: 0 0` to anchor pan/zoom scaling to the top-left corner

🤖 Generated with [Claude Code](https://claude.com/claude-code)