### PR TITLE
Use .env for configurable save file path in Docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 .claude/
 CLAUDE.md
+server/.env

--- a/README.md
+++ b/README.md
@@ -25,7 +25,19 @@ This application can run as a Docker container that automatically loads the game
 
 ### Setup
 
-1. Edit `server/docker-compose.yml` to update the volume mount path if your Cemu save file is in a different location.
+1. Create a `server/.env` file to configure your Cemu save file path.
+
+   **If running Docker from WSL (Linux-style path):**
+   ```
+   SAVE_PATH=/mnt/c/Users/YourWindowsUsername/AppData/Roaming/Cemu/mlc01/usr/save/00050000/101c9400/user/80000001/0
+   ```
+
+   **If running Docker from Windows (Command Prompt or PowerShell):**
+   ```
+   SAVE_PATH=C:/Users/YourWindowsUsername/AppData/Roaming/Cemu/mlc01/usr/save/00050000/101c9400/user/80000001/0
+   ```
+
+   Replace `YourWindowsUsername` with your Windows username. The save folder ID (`80000001`) may also differ — check your Cemu save directory if unsure.
 
 2. Build and start the container:
    ```bash

--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -4,7 +4,7 @@ services:
       context: ..
       dockerfile: server/Dockerfile
     volumes:
-      - /mnt/c/Users/pphil/AppData/Roaming/Cemu/mlc01/usr/save/00050000/101c9400/user/80000001/0:/app/data
+      - ${SAVE_PATH}:/app/data
     ports:
       - "3000:3000"
     container_name: botw-webserver


### PR DESCRIPTION
## Summary

- Removed the hard-coded personal Windows/WSL path from `server/docker-compose.yml`
- Save file path is now configured via a `server/.env` file, making the setup portable for any user

## Changes

### `server/docker-compose.yml`
- Volume mount path replaced with `${SAVE_PATH}` variable sourced from `server/.env`

### `server/.env` *(gitignored)*
- New file (not committed) where each user defines their own `SAVE_PATH`

### `.gitignore`
- Added `server/.env` to prevent personal paths from being accidentally committed

### `README.md`
- Updated Docker setup instructions to document the `.env` file requirement
- Added separate examples for both **WSL** (Linux-style) and **Windows** (forward-slash) path formats

## Notes
- Users cloning this repo must create `server/.env` before running Docker — see README for details

🤖 Generated with [Claude Code](https://claude.com/claude-code)