### PR TITLE
Update README to reflect auto-loading Docker setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,24 +4,19 @@
 
 I was sitting around 600 Koroks found and was having a really difficult time following any sort of checklist to find the rest since I would need to check off all 600 that I found before it would be useful for me.
 
-So, I slapped this together to parse a save file from the game to show only the ones that I have yet to find. I also added Locations on there for good measure as they play into the percentage on the map as well.
+So, I slapped this together to parse a Cemu save file to show only the Koroks and Locations that I have yet to find. As you find them in-game, the map automatically refreshes to reflect your progress.
 
 As you find Koroks/Locations, clicking on them will remove them from the map.
 
-Once a save file has been loaded, the parsed data is saved into your web browser, so you can close the window whenever you like without losing anything. It will also remember any markers that you have removed.
-
-If you would rather use this as a checklist _without_ loading a save file, that option is available as well.
-
 Thank you @marcrobledo for the [save game editors](https://github.com/marcrobledo/savegame-editors) much of this code is based off of and @MrCheeze for the their [waypoint map](https://github.com/MrCheeze/botw-waypoint-map) which I modified to get the map markers I needed as well as all of their [datamining research](https://github.com/MrCheeze/botw-tools).
 
-## Docker Setup (Server Mode)
+## Docker Setup
 
-This application can run as a Docker container that automatically loads the game save file and monitors for changes.
+This application runs as a Docker container that automatically reads your Cemu save file and monitors it for changes, refreshing the map whenever you save in-game.
 
 ### Requirements
 
-- Docker
-- Docker Compose
+- Docker and Docker Compose running on the same machine as your Cemu save file (or with network access to it)
 
 ### Setup
 
@@ -49,11 +44,6 @@ This application can run as a Docker container that automatically loads the game
 
 ### How It Works
 
-- The server automatically loads the game save file from the mounted data directory
+- The server reads your Cemu save file from the path defined in `server/.env`
 - The save file is monitored for changes every 10 seconds
-- When the save file is updated (e.g., after playing the game), the page automatically refreshes to show updated data
-- No manual drag-and-drop or file selection required
-
-### Data Directory
-
-The save file path is configured in `server/docker-compose.yml`. By default, it mounts the Cemu save directory to `/app/data` inside the container.
+- When the save file is updated after playing, the page automatically refreshes to show your latest progress


### PR DESCRIPTION
## Summary

- Rewrote README to accurately describe the current Docker-based workflow
- Removed outdated references to manual save file loading

## Changes

### `README.md`
- Removed references to manually loading save files, drag-and-drop file selection, and browser storage of parsed data
- Removed the "use as a checklist without a save file" option
- Updated intro to describe the Cemu save file auto-loading behavior
- Renamed section from "Docker Setup (Server Mode)" to "Docker Setup"
- Added requirement that Docker must run on the same machine (or have network access) as the Cemu save file
- Removed redundant "Data Directory" section, consolidated into "How It Works"

🤖 Generated with [Claude Code](https://claude.com/claude-code)