### PR TITLE
UI restyle, responsive layout, new metrics, and server status indicator

### DIFF
--- a/assets/css/zelda-botw.css
+++ b/assets/css/zelda-botw.css
@@ -208,6 +208,7 @@ button.with-icon.file-load:before{background-position:-32px -48px;width:20px;hei
 	padding:5px 0;
 	background:rgba(26,58,82,0.4);
 	border-top:1px solid rgba(201,169,89,0.25);
+	position:relative;
 }
 #span-version:hover{text-decoration:underline}
 #header h1{
@@ -276,13 +277,14 @@ button.with-icon.file-load:before{background-position:-32px -48px;width:20px;hei
 	color:var(--botw-text-muted);
 	text-transform:uppercase;
 	letter-spacing:1px;
-	font-size:0.7rem;
-	margin:0 14px;
+	font-size:clamp(6px, 0.85vw, 11px);
+	margin:0 clamp(4px, 1vw, 14px);
+	white-space:nowrap;
 }
 #toolbar label span{
 	font-family:'Cinzel',serif;
 	color:var(--botw-gold);
-	font-size:0.95rem;
+	font-size:clamp(7px, 1.1vw, 15px);
 	font-weight:600;
 	text-shadow:0 0 10px rgba(201,169,89,0.4);
 }
@@ -292,12 +294,43 @@ button.with-icon.file-load:before{background-position:-32px -48px;width:20px;hei
 	justify-content:center;
 	gap:6px;
 }
+#server-status{
+	position:absolute;
+	right:16px;
+	top:50%;
+	transform:translateY(-50%);
+	display:flex;
+	align-items:center;
+	gap:6px;
+}
+#save-timestamp-label,
+#save-timestamp{
+	font-size:clamp(5px, 0.75vw, 10px);
+	color:var(--botw-text-muted);
+	letter-spacing:0.5px;
+	font-family:'Noto Sans',sans-serif;
+	white-space:nowrap;
+}
+.server-status-dot{
+	width:8px;
+	height:8px;
+	border-radius:50%;
+	display:inline-block;
+	flex-shrink:0;
+}
+.server-status-dot.online{
+	background-color:#4caf50;
+	box-shadow:0 0 6px rgba(76,175,80,0.8);
+}
+.server-status-dot.offline{
+	background-color:#555;
+}
 #toolbar label #span-number-total-locations,
 #toolbar label #span-number-total-shrines,
 #toolbar label #span-number-total-towers{
 	color:var(--botw-text-muted);
 	font-family:'Noto Sans',sans-serif;
-	font-size:0.95rem;
+	font-size:clamp(7px, 1.1vw, 15px);
 	font-weight:400;
 	text-shadow:none;
 }

--- a/assets/js/zelda-botw.js
+++ b/assets/js/zelda-botw.js
@@ -291,18 +291,38 @@ window.addEventListener('load',function(){
 	if (typeof EventSource !== 'undefined') {
 		const eventSource = new EventSource('/api/events');
 		eventSource.onmessage = function(event) {
-			if (event.data === 'changed') {
-				// Reload the save file
+			var data;
+			try { data = JSON.parse(event.data); } catch(e) { data = { event: event.data }; }
+			if (data.event === 'connected' || data.event === 'changed') {
+				setServerOnline(true);
+				if (data.mtime) updateSaveTimestamp(data.mtime);
+			}
+			if (data.event === 'changed') {
 				loadSaveFromServer();
 			}
 		};
 		eventSource.onerror = function() {
+			setServerOnline(false);
 			// Fall back to polling
 			setInterval(loadSaveFromServer, 10000);
 		};
 	} else {
 		// Fallback for browsers without SSE support - poll every 10 seconds
 		setInterval(loadSaveFromServer, 10000);
+	}
+
+	function setServerOnline(online) {
+		var dot = document.getElementById('server-status-dot');
+		if (dot) dot.className = 'server-status-dot ' + (online ? 'online' : 'offline');
+	}
+
+	function updateSaveTimestamp(mtime) {
+		var el = document.getElementById('save-timestamp');
+		if (!el) return;
+		var d = new Date(mtime);
+		var pad = function(n) { return n < 10 ? '0' + n : n; };
+		el.textContent = pad(d.getMonth()+1) + '/' + pad(d.getDate()) + '/' + d.getFullYear()
+			+ ' ' + pad(d.getHours()) + ':' + pad(d.getMinutes()) + ':' + pad(d.getSeconds());
 	}
 
 	// If there is saved data in the browser, load that instead

--- a/index.html
+++ b/index.html
@@ -30,7 +30,7 @@
 	</div>
 	<div id="toolbar" class="hidden padding-vertical">
 		<div class="row wrapper">
-			<div class="twelve columns text-center"> 
+			<div class="twelve columns text-center">
 				<label for="span-number-koroks">Korok seeds
 					<span id="span-number-koroks"></span>/900
 				</label>
@@ -46,7 +46,12 @@
 				<label for="span-number-towers">Towers
 					<span id="span-number-towers"></span>/<span id="span-number-total-towers"></span>
 				</label>
-				</div>
+			</div>
+		</div>
+		<div id="server-status">
+			<span id="save-timestamp-label">Last Updated:</span>
+			<span id="save-timestamp"></span>
+			<span id="server-status-dot" class="server-status-dot offline"></span>
 		</div>
 	</div>
 </div>

--- a/server/server.js
+++ b/server/server.js
@@ -34,15 +34,10 @@ app.get('/api/events', (req, res) => {
     res.setHeader('Connection', 'keep-alive');
     res.flushHeaders();
 
-    // Send initial connection message
-    res.write('data: connected\n\n');
-
-    // Store last file modification time
-    let lastMtime = null;
-
     const filePath = path.join(__dirname, DATA_PATH);
 
-    // Check file exists and get initial mtime
+    // Store last file modification time and get initial mtime
+    let lastMtime = null;
     try {
         const stats = fs.statSync(filePath);
         lastMtime = stats.mtimeMs;
@@ -50,13 +45,16 @@ app.get('/api/events', (req, res) => {
         console.error('Initial file check error:', err);
     }
 
+    // Send initial connection message with current mtime
+    res.write('data: ' + JSON.stringify({ event: 'connected', mtime: lastMtime }) + '\n\n');
+
     // Poll for file changes every 10 seconds
     const interval = setInterval(() => {
         try {
             const stats = fs.statSync(filePath);
             if (lastMtime && stats.mtimeMs !== lastMtime) {
                 lastMtime = stats.mtimeMs;
-                res.write('data: changed\n\n');
+                res.write('data: ' + JSON.stringify({ event: 'changed', mtime: stats.mtimeMs }) + '\n\n');
             } else if (!lastMtime) {
                 lastMtime = stats.mtimeMs;
             }


### PR DESCRIPTION
## Summary
- **Sheikah-tablet dark theme**: dark background with gold/cyan accents, Cinzel serif font, animated header pulse line, and decorative map corner brackets
- **Fully responsive layout**: header title, author credits, and all toolbar text scale with viewport width via `clamp()` — no wrapping at any window size; map fills the full browser window with no scrollbars
- **Map initializes fully zoomed out** on load and pans/zooms correctly without position jumps
- **New toolbar metrics**: Shrines (found/120) and Towers (found/15) counters derived from save file data alongside existing Korok Seeds and Locations
- **Consistent counter styling**: all totals display in muted grey; found counts in gold Cinzel
- **Locations total** corrected to 226 per game sources
- **Server status indicator**: green LED + "Last Updated: MM/DD/YYYY HH:MM:SS" timestamp anchored to the right edge of the toolbar, sourced from the save file's mtime via SSE

## Test plan
- [ ] Load app — header and all metrics visible immediately, no scrollbars
- [ ] Map loads fully zoomed out and centered; zoom/pan works without position shift
- [ ] Resize browser window — all header and toolbar text scales without wrapping
- [ ] Green LED lit and timestamp shown after save file loads
- [ ] Korok Seeds, Locations, Shrines, and Towers all show correct found/total counts
- [ ] All totals (Locations/226, Shrines/120, Towers/15) shown in muted grey
- [ ] Save file update triggers map refresh and updates the timestamp

🤖 Generated with [Claude Code](https://claude.com/claude-code)