### PR TITLE
Bind server to 0.0.0.0 for network accessibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,9 @@ This application runs as a Docker container that automatically reads your Cemu s
    docker compose up -d --build
    ```
 
-3. Open http://localhost:3000 in your browser.
+3. Open the viewer in your browser:
+   - From the same machine: http://localhost:3000
+   - From another device on your network: `http://<docker-host-ip>:3000` (e.g. `http://192.168.1.100:3000`)
 
 ### How It Works
 

--- a/server/server.js
+++ b/server/server.js
@@ -71,6 +71,6 @@ app.get('/api/events', (req, res) => {
     });
 });
 
-app.listen(PORT, () => {
+app.listen(PORT, '0.0.0.0', () => {
     console.log(`Server running at http://localhost:${PORT}`);
 });


### PR DESCRIPTION
## Summary
- Bind Express to `0.0.0.0` so the container is reachable from the Docker host's IP, not just `localhost`
- Update README step 3 to document both `localhost:3000` and `<host-ip>:3000` access methods

## Test plan
- [ ] `docker compose up -d --build` from `server/`
- [ ] Confirm http://localhost:3000 still works from the host machine
- [ ] Confirm http://\<host-ip\>:3000 is accessible from another device on the same network

🤖 Generated with [Claude Code](https://claude.com/claude-code)