### PR TITLE
Add Divine Beasts completion metric to toolbar

### DIFF
--- a/assets/css/zelda-botw.css
+++ b/assets/css/zelda-botw.css
@@ -327,7 +327,8 @@ button.with-icon.file-load:before{background-position:-32px -48px;width:20px;hei
 }
 #toolbar label #span-number-total-locations,
 #toolbar label #span-number-total-shrines,
-#toolbar label #span-number-total-towers{
+#toolbar label #span-number-total-towers,
+#toolbar label #span-number-total-divine-beasts{
 	color:var(--botw-text-muted);
 	font-family:'Noto Sans',sans-serif;
 	font-size:clamp(7px, 1.1vw, 15px);

--- a/assets/js/zelda-botw.js
+++ b/assets/js/zelda-botw.js
@@ -7,6 +7,7 @@ var locationValues = {};
 
 var shrines = {};
 var towers = {};
+var divineBeasts = {};
 
 SavegameEditor={
 	Name:'The legend of Zelda: Breath of the wild',
@@ -108,6 +109,7 @@ SavegameEditor={
 			'locations': {},
 			'shrines': {},
 			'towers': {},
+			'divineBeasts': {},
 		};
 
 		locationValues.found = {
@@ -115,6 +117,7 @@ SavegameEditor={
 			'locations': 0,
 			'shrines': 0,
 			'towers': 0,
+			'divineBeasts': 0,
 		};
 
 		// All Korok/Location Data filtered down to ones not found
@@ -122,6 +125,7 @@ SavegameEditor={
 		this._notFoundLocations( locations, 'locations' );
 		this._notFoundLocations( shrines, 'shrines' );
 		this._notFoundLocations( towers, 'towers' );
+		this._notFoundLocations( divineBeasts, 'divineBeasts' );
 
 		window.localStorage.setItem( 'botw-unexplored-viewer', JSON.stringify( locationValues ) );
 
@@ -131,6 +135,8 @@ SavegameEditor={
 		setValue( 'span-number-total-shrines', Object.keys( shrines ).length );
 		setValue( 'span-number-towers', locationValues.found.towers );
 		setValue( 'span-number-total-towers', Object.keys( towers ).length );
+		setValue( 'span-number-divine-beasts', locationValues.found.divineBeasts );
+		setValue( 'span-number-total-divine-beasts', Object.keys( divineBeasts ).length );
 
 		this.drawKorokPaths( locationValues.notFound.koroks );
 
@@ -265,6 +271,8 @@ window.addEventListener('load',function(){
 			shrines[_warpHash] = warps[_warpHash];
 		} else if (warps[_warpHash].internal_name.indexOf('Location_MapTower') === 0) {
 			towers[_warpHash] = warps[_warpHash];
+		} else if (warps[_warpHash].internal_name.indexOf('Location_Remains') === 0) {
+			divineBeasts[_warpHash] = warps[_warpHash];
 		}
 	}
 
@@ -333,6 +341,7 @@ window.addEventListener('load',function(){
 			'locations': {},
 			'shrines': {},
 			'towers': {},
+			'divineBeasts': {},
 		};
 
 		locationValues.found = {
@@ -340,6 +349,7 @@ window.addEventListener('load',function(){
 			'locations': 0,
 			'shrines': 0,
 			'towers': 0,
+			'divineBeasts': 0,
 		};
 
 		for ( var hash in koroks ) {
@@ -373,6 +383,8 @@ window.addEventListener('load',function(){
 		setValue( 'span-number-total-shrines', Object.keys( shrines ).length );
 		setValue( 'span-number-towers', locationValues.found.towers );
 		setValue( 'span-number-total-towers', Object.keys( towers ).length );
+		setValue( 'span-number-divine-beasts', locationValues.found.divineBeasts );
+		setValue( 'span-number-total-divine-beasts', Object.keys( divineBeasts ).length );
 
 		SavegameEditor.drawKorokPaths( locationValues.notFound.koroks );
 

--- a/index.html
+++ b/index.html
@@ -46,6 +46,10 @@
 				<label for="span-number-towers">Towers
 					<span id="span-number-towers"></span>/<span id="span-number-total-towers"></span>
 				</label>
+				|
+				<label for="span-number-divine-beasts">Divine Beasts
+					<span id="span-number-divine-beasts"></span>/<span id="span-number-total-divine-beasts"></span>
+				</label>
 			</div>
 		</div>
 		<div id="server-status">


### PR DESCRIPTION
## Summary
- Splits `Location_Remains*` warp entries into a dedicated `divineBeasts` tracker, mirroring the existing shrines/towers pattern
- Reads save file completion flags via `_notFoundLocations` and displays a **Divine Beasts X/4** counter in the toolbar
- Fixes the `/4` total span color to render in muted grey (matching Locations, Shrines, Towers totals) instead of inheriting gold

## Test plan
- [ ] Load a save file and verify Divine Beasts counter reflects completed beasts
- [ ] Verify `/4` total is grey, not gold
- [ ] Verify other metrics (koroks, locations, shrines, towers) are unaffected
- [ ] Verify "fresh map" (no save) shows 0/4

🤖 Generated with [Claude Code](https://claude.com/claude-code)