### PR TITLE
Add Player Stats sidebar, Player Position marker, and debug API

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,23 +6,52 @@ I was sitting around 600 Koroks found and was having a really difficult time fol
 
 So, I slapped this together to parse a Cemu save file to show only the Koroks and Locations that I have yet to find. As you find them in-game, the map automatically refreshes to reflect your progress.
 
-A collapsible sidebar tracks your running totals for:
-- **Korok seeds** (out of 900)
-- **Locations** (out of 226)
-- **Shrines Discovered** — shrines with a warp point unlocked (out of 120)
-- **Shrines Completed** — shrines with a Spirit Orb collected (out of 120)
-- **Towers** (out of 15)
-- **Divine Beasts** (out of 4)
+A fixed sidebar on the left tracks your progress across two sections:
 
-Each metric category is color-coded and interactive:
+#### Location Metrics
+Each entry is color-coded, hoverable, and toggleable:
+
+| Metric | Color | Total |
+|--------|-------|-------|
+| Korok seeds | Green | 900 |
+| Locations | Orange | 226 |
+| Shrines Discovered | Cyan | 120 |
+| Shrines Completed | Yellow | 120 |
+| Towers | Violet | 15 |
+| Divine Beasts | Red | 4 |
+| Player Position | White | — |
+
 - **Hover** over a metric to highlight all matching icons on the map with a glowing ring
 - **Click** a metric to show/hide that icon type on the map; hidden categories appear dimmed in the sidebar
+- **Player Position** places a glowing white marker on the map at your character's last saved location
+
+#### Player Stats
+Read directly from the save file — no game interaction required:
+
+| Stat | Notes |
+|------|-------|
+| Hearts | Max heart containers |
+| Stamina | Max stamina wheels (1.0–3.0 in 0.2 increments) |
+| Playtime | Total time played (H:MM:SS) |
+| Rupees | Current rupee count |
+| Motorcycle | Green = Master Cycle owned, Red = not yet |
 
 Map icons use shape and color to indicate type:
 - **Circles** — Korok seeds (green) and Locations (orange)
 - **Diamonds** — Shrines discovered (cyan), Shrines completed (yellow), Towers (violet), Divine Beasts (red), and other Warp Points
+- **Glowing circle** — Player position (white)
 
-A server status indicator and save file timestamp in the sidebar let you know the server is reachable and when your save was last read.
+A server status indicator and save file timestamp at the bottom of the sidebar show server reachability and when your save was last read.
+
+### Debug API
+
+A JSON endpoint is available for troubleshooting:
+
+```
+GET http://localhost:3000/api
+```
+
+Returns all parsed save file metrics including raw and display values for hearts, stamina, playtime, rupees, motorcycle status, player coordinates (X/Y/Z), and found/total counts for all location categories.
 
 ![Unexplored Area Viewer screenshot](Screenshot.jpg)
 
@@ -67,3 +96,7 @@ This application runs as a Docker container that automatically reads your Cemu s
 - The server reads your Cemu save file from the path defined in `server/.env`
 - The save file is monitored for changes every 10 seconds
 - When the save file is updated after playing, the page automatically refreshes to show your latest progress
+
+### Supported Game Versions
+
+Wii U and Switch saves are both supported. Recognized versions: v1.0, v1.1, v1.2, v1.3, v1.3.1, v1.3.3, v1.3.4, v1.4, v1.5, v1.5*, v1.6, v1.6*, v1.6**, v1.6***, v1.8, Kiosk. Modded saves with non-standard file sizes are also accepted.

--- a/assets/css/zelda-botw.css
+++ b/assets/css/zelda-botw.css
@@ -219,12 +219,19 @@ button.with-icon.file-load:before{background-position:-32px -48px;width:20px;hei
 	z-index:99;
 }
 #span-version:hover{text-decoration:underline}
+#header-row{
+	display:grid;
+	grid-template-columns:1fr auto;
+	align-items:center;
+	padding:8px 12px 8px 0;
+	width:100%;
+	box-sizing:border-box;
+}
 #header h1{
-	display:inline-block;
+	display:block;
 	font-size:clamp(8px, 1.35vw, 13px);
 	margin:0;
-	flex:1;
-	min-width:0;
+	text-align:center;
 	white-space:nowrap;
 	overflow:hidden;
 	color:var(--botw-gold);
@@ -232,7 +239,6 @@ button.with-icon.file-load:before{background-position:-32px -48px;width:20px;hei
 	text-shadow:0 0 15px rgba(201,169,89,0.4);
 }
 #header h1 img{vertical-align:middle}
-#header-top .padding-vertical{padding:8px 0}
 
 
 
@@ -313,6 +319,7 @@ button.with-icon.file-load:before{background-position:-32px -48px;width:20px;hei
 .dot-shrine-completed { background:#ffff00; }
 .dot-tower            { background:#cc00ff; }
 .dot-divine-beast     { background:#ff2200; }
+.dot-player-position  { background:#ffffff; }
 
 #toolbar label .stat-subtitle{
 	display:inline;
@@ -339,6 +346,97 @@ button.with-icon.file-load:before{background-position:-32px -48px;width:20px;hei
 	font-weight:600;
 	text-shadow:0 0 10px rgba(201,169,89,0.4);
 }
+#player-stats-section{
+	padding:10px 8px 8px;
+	border-top:3px double rgba(100,120,140,0.55);
+	border-bottom:3px double rgba(100,120,140,0.55);
+	display:flex;
+	flex-direction:column;
+	gap:6px;
+}
+.player-stats-title{
+	font-family:'Cinzel',serif;
+	font-size:11px;
+	font-weight:700;
+	color:var(--botw-text-muted);
+	text-transform:uppercase;
+	letter-spacing:0.5px;
+	margin-bottom:2px;
+}
+.player-stat-row{
+	display:flex;
+	justify-content:space-between;
+	align-items:center;
+}
+.player-stat-label{
+	font-family:'Noto Sans',sans-serif;
+	font-size:10px;
+	color:var(--botw-text-muted);
+}
+.player-stat-value{
+	font-family:'Cinzel',serif;
+	font-size:12px;
+	color:var(--botw-gold);
+	font-weight:600;
+	text-shadow:0 0 8px rgba(201,169,89,0.4);
+}
+.motorcycle-light{
+	width:10px;
+	height:10px;
+	border-radius:50%;
+	display:inline-block;
+	flex-shrink:0;
+}
+.motorcycle-light.owned{
+	background-color:#4caf50;
+	box-shadow:0 0 6px rgba(76,175,80,0.9);
+}
+.motorcycle-light.not-owned{
+	background-color:#c0392b;
+	box-shadow:0 0 4px rgba(192,57,43,0.6);
+}
+#shape-legend{
+	padding:10px 8px 8px;
+	border-top:1px solid rgba(201,169,89,0.15);
+	display:flex;
+	flex-direction:column;
+	gap:5px;
+}
+.shape-legend-title{
+	font-family:'Cinzel',serif;
+	font-size:11px;
+	font-weight:700;
+	color:var(--botw-text-muted);
+	text-transform:uppercase;
+	letter-spacing:0.5px;
+}
+.shape-legend-row{
+	display:flex;
+	align-items:center;
+	gap:8px;
+}
+.shape-legend-icon{
+	flex-shrink:0;
+	width:10px;
+	height:10px;
+	background:var(--botw-text-muted);
+	display:inline-block;
+}
+.shape-legend-icon.shape-circle{
+	border-radius:50%;
+}
+.shape-legend-icon.shape-diamond{
+	border-radius:0;
+	transform:rotate(45deg);
+	width:8px;
+	height:8px;
+}
+.shape-legend-label{
+	font-family:'Noto Sans',sans-serif;
+	font-size:9px;
+	color:var(--botw-text-muted);
+	white-space:nowrap;
+}
 #server-status{
 	margin-top:auto;
 	display:flex;
@@ -346,14 +444,15 @@ button.with-icon.file-load:before{background-position:-32px -48px;width:20px;hei
 	align-items:flex-start;
 	gap:4px;
 	padding:10px 10px;
-	border-top:1px solid rgba(201,169,89,0.2);
+	border-top:3px double rgba(100,120,140,0.55);
 }
 #save-timestamp-label{
+	font-family:'Cinzel',serif;
 	font-size:11px;
-	font-weight:600;
+	font-weight:700;
 	color:var(--botw-text-muted);
 	letter-spacing:0.5px;
-	font-family:'Noto Sans',sans-serif;
+	text-transform:uppercase;
 	white-space:nowrap;
 }
 #save-timestamp{
@@ -863,6 +962,18 @@ button.no-text.with-icon:before{margin-right:0px}
 	border-radius: 0;
 	transform: translate(-2px,0px) rotate(45deg);
 	transform-origin: top right;
+}
+
+#map-container .waypoint.player-position {
+	background: #ffffff;
+	border: 2px solid rgba(200,200,200,0.7);
+	width: 14px;
+	height: 14px;
+	border-radius: 50%;
+	transform: translate(-7px,-7px);
+	box-shadow: 0 0 10px 4px rgba(255,255,255,0.7), 0 0 20px 6px rgba(255,255,255,0.3);
+	z-index: 100;
+	cursor: default;
 }
 
 #map-container .waypoint.warp {

--- a/assets/js/zelda-botw.js
+++ b/assets/js/zelda-botw.js
@@ -22,9 +22,9 @@ SavegameEditor={
 		STRING_SIZE:0x80,
 
 		//missing versions: 1.1.1, 1.1.2 and 1.4.1
-		VERSION:				['v1.0', 'v1.1', 'v1.2', 'v1.3', 'v1.3.1', 'Kiosk', 'v1.3.3','v1.3.4', 'v1.4',  'v1.5',  'v1.6',  'v1.6*', 'v1.6**','v1.6***'],
-		FILESIZE:				[896976, 897160, 897112, 907824, 907824,  916576,  1020648, 1020648,   1027208, 1027208, 1027216, 1027216, 1027216, 1027216],
-		HEADER:					[0x24e2, 0x24ee, 0x2588, 0x29c0, 0x2a46,  0x2f8e,  0x3ef8,  0x3ef9,    0x471a,  0x471b,  0x471e, 0x0f423d, 0x0f423e,0x0f423f],
+		VERSION:				['v1.0', 'v1.1', 'v1.2', 'v1.3', 'v1.3.1', 'Kiosk', 'v1.3.3','v1.3.4', 'v1.4',  'v1.5',  'v1.6',  'v1.6*', 'v1.6**','v1.6***', 'v1.5*', 'v1.8'],
+		FILESIZE:				[896976, 897160, 897112, 907824, 907824,  916576,  1020648, 1020648,   1027208, 1027208, 1027216, 1027216, 1027216, 1027216,   1027248, 1027248],
+		HEADER:					[0x24e2, 0x24ee, 0x2588, 0x29c0, 0x2a46,  0x2f8e,  0x3ef8,  0x3ef9,    0x471a,  0x471b,  0x471e, 0x0f423d, 0x0f423e,0x0f423f,   0x471b,  0x4730],
 
 		MAP_ICONS: 0x9383490e,
 		MAP_POS: 0xea9def3f,
@@ -33,7 +33,7 @@ SavegameEditor={
 
 	/* Offsets */
 	Hashes:[
-		0x8a94e07a, 'KOROK_SEED_COUNTER',			
+		0x8a94e07a, 'KOROK_SEED_COUNTER',
 	],
 
 
@@ -84,6 +84,10 @@ SavegameEditor={
 
 			if(tempFile.fileSize===this.Constants.FILESIZE[i] && versionHash===this.Constants.HEADER[i] && tempFile.readU32(4)===0xffffffff){
 				this._getOffsets(i);
+				return true;
+			}else if((tempFile.fileSize>=896976 && tempFile.fileSize<=1500000) && versionHash===this.Constants.HEADER[i] && tempFile.readU32(4)===0xffffffff){
+				this._getOffsets(i);
+				setValue('version', this.Constants.VERSION[i]+'<small>mod</small> ('+CONSOLE+')');
 				return true;
 			}
 		}
@@ -161,6 +165,28 @@ SavegameEditor={
 		this.markMap( divineBeasts, 'divine-beast' );
 		this.markMap( remainingWarps, 'warp' );
 		this.markMap( locationValues.notFound.koroks, 'korok' );
+
+		// Player position — three consecutive identical-hash pairs: [hash,X] [hash,Y] [hash,Z]
+		var _pos = this._searchHash(0xa40ba103);
+		if (_pos !== false) {
+			var playerX = tempFile.readF32(_pos + 4);  // first  pair value = X (east/west)
+			// _pos+8 = second hash, _pos+12 = Y (height) — skip
+			var playerZ = tempFile.readF32(_pos + 20); // third pair value = Z (north/south)
+			if (!isNaN(playerX) && !isNaN(playerZ)) placePlayerMarker(playerX, playerZ);
+		}
+
+		// Player stats — each searched independently
+		var _sh;
+		_sh = this._searchHash(0x2906f327); // MAX_HEARTS — U32 quarter-heart units (÷4 = displayed hearts)
+		if (_sh !== false) setValue('span-stat-hearts', tempFile.readU32(_sh+4) / 4);
+		_sh = this._searchHash(0x3adff047); // MAX_STAMINA — stored as F32, units of 1/1000 wheel
+		if (_sh !== false) { var _sv = tempFile.readF32(_sh+4); setValue('span-stat-stamina', isNaN(_sv) ? '\u2014' : (_sv/1000).toFixed(1)); }
+		_sh = this._searchHash(0x73c29681); // PLAYTIME
+		if (_sh !== false) setValue('span-stat-playtime', formatPlaytime(tempFile.readU32(_sh+4)));
+		_sh = this._searchHash(0x23149bf8); // RUPEES
+		if (_sh !== false) setValue('span-stat-rupees', tempFile.readU32(_sh+4).toLocaleString());
+		_sh = this._searchHash(0xc9328299); // MOTORCYCLE
+		if (_sh !== false) setMotorcycleIndicator(tempFile.readU32(_sh+4) > 0);
 
 		addWaypointListeners();
 		applyHiddenStates();
@@ -557,6 +583,31 @@ function removeAllWaypoints() {
 		element.remove();
 	} );
 
+}
+
+function placePlayerMarker(x, z) {
+	var map = document.getElementById('map-container');
+	var existing = document.getElementById('player-position-marker');
+	if (existing) existing.remove();
+	var marker = document.createElement('div');
+	marker.id = 'player-position-marker';
+	marker.classList.add('waypoint', 'player-position');
+	marker.style.left = (3000 + x / 2) + 'px';
+	marker.style.top  = (2500 + z / 2) + 'px';
+	marker.setAttribute('data-display_name', 'Player');
+	map.appendChild(marker);
+}
+
+function formatPlaytime(seconds) {
+	var h = Math.floor(seconds / 3600);
+	var m = Math.floor((seconds % 3600) / 60);
+	var s = seconds % 60;
+	return h + ':' + (m < 10 ? '0' + m : m) + ':' + (s < 10 ? '0' + s : s);
+}
+
+function setMotorcycleIndicator(owned) {
+	var el = document.getElementById('stat-motorcycle-light');
+	if (el) el.className = 'motorcycle-light ' + (owned ? 'owned' : 'not-owned');
 }
 
 // Map pan and zoom functionality

--- a/index.html
+++ b/index.html
@@ -21,9 +21,9 @@
 <!-- HEADER -->
 <div id="header">
 	<div id="header-top">
-		<div class="row wrapper padding-vertical">
+		<div id="header-row" class="padding-vertical">
 			<h1>Unexplored Area Viewer for The Legend of Zelda: BOTW</h1>
-			<div class="six columns text-right header-buttons">
+			<div class="header-buttons">
 				by <a href="https://github.com/d4mation" target="_blank" class="author">Eric Defore</a> and <a href="https://github.com/Xanderphillips" target="_blank" class="author">Xanderphillips</a>
 			</div>
 		</div>
@@ -55,6 +55,43 @@
 		<span class="legend-bar dot-divine-beast"></span>
 		<span class="stat-value"><span id="span-number-divine-beasts"></span>/<span id="span-number-total-divine-beasts"></span></span>
 	</label>
+	<label data-type="player-position">Player Pos
+		<span class="legend-bar dot-player-position"></span>
+	</label>
+	<div id="player-stats-section">
+		<div class="player-stats-title">Player Stats</div>
+		<div class="player-stat-row">
+			<span class="player-stat-label">Hearts</span>
+			<span class="player-stat-value" id="span-stat-hearts">&mdash;</span>
+		</div>
+		<div class="player-stat-row">
+			<span class="player-stat-label">Stamina</span>
+			<span class="player-stat-value" id="span-stat-stamina">&mdash;</span>
+		</div>
+		<div class="player-stat-row">
+			<span class="player-stat-label">Playtime</span>
+			<span class="player-stat-value" id="span-stat-playtime">&mdash;</span>
+		</div>
+		<div class="player-stat-row">
+			<span class="player-stat-label">Rupees</span>
+			<span class="player-stat-value" id="span-stat-rupees">&mdash;</span>
+		</div>
+		<div class="player-stat-row">
+			<span class="player-stat-label">Motorcycle</span>
+			<span class="motorcycle-light not-owned" id="stat-motorcycle-light"></span>
+		</div>
+	</div>
+	<div id="shape-legend">
+		<div class="shape-legend-title">Icon Shapes</div>
+		<div class="shape-legend-row">
+			<span class="shape-legend-icon shape-circle"></span>
+			<span class="shape-legend-label">Points of Interest</span>
+		</div>
+		<div class="shape-legend-row">
+			<span class="shape-legend-icon shape-diamond"></span>
+			<span class="shape-legend-label">Warp Points</span>
+		</div>
+	</div>
 	<div id="server-status">
 		<span id="save-timestamp-label">Last Updated:</span>
 		<div id="timestamp-row">

--- a/server/server.js
+++ b/server/server.js
@@ -40,6 +40,148 @@ app.get('/api/mtime', (req, res) => {
     });
 });
 
+// Parse map-locations.js to extract hash → internal_name tables for each category
+function loadMapHashes() {
+    const content = fs.readFileSync(path.join(__dirname, 'assets/js/map-locations.js'), 'utf8');
+
+    function extractSection(name) {
+        const start = content.indexOf(`var ${name} = {`);
+        if (start < 0) return {};
+        const end = content.indexOf('\n    };', start);
+        const section = content.slice(start, end);
+        const result = {};
+        const re = /0x([0-9a-fA-F]+):\s*\{"internal_name":"([^"]+)"/g;
+        let m;
+        while ((m = re.exec(section)) !== null)
+            result[parseInt(m[1], 16)] = m[2];
+        return result;
+    }
+
+    const warps = extractSection('warps');
+    const shrines = {}, towers = {}, divineBeasts = {}, otherWarps = {};
+    for (const h in warps) {
+        const n = warps[h];
+        if (n.startsWith('Location_Dungeon'))   shrines[h] = n;
+        else if (n.startsWith('Location_MapTower')) towers[h] = n;
+        else if (n.startsWith('Location_Remains')) divineBeasts[h] = n;
+        else otherWarps[h] = n;
+    }
+
+    return {
+        locations:         extractSection('locations'),
+        shrines,
+        towers,
+        divineBeasts,
+        koroks:            extractSection('koroks'),
+        shrineCompletions: extractSection('shrineCompletions'),
+    };
+}
+
+// Scan save buffer for found/total counts of a hash table
+// A flag is "found" when its value field (offset+4) is non-zero
+function scanFlags(buf, readU32, hashTable) {
+    const found = new Set();
+    const total = Object.keys(hashTable).length;
+    for (let i = 0x0c; i < buf.length - 4; i += 8) {
+        const hash = readU32(i);
+        if (Object.prototype.hasOwnProperty.call(hashTable, hash) && readU32(i + 4) !== 0)
+            found.add(hash);
+    }
+    return { found: found.size, total };
+}
+
+// Parse BotW save file hashes server-side for debug inspection
+function parseSaveMetrics(buf) {
+    function makeReaders(le) {
+        return {
+            u32: (o) => le ? buf.readUInt32LE(o) : buf.readUInt32BE(o),
+            f32: (o) => le ? buf.readFloatLE(o)  : buf.readFloatBE(o),
+        };
+    }
+    function searchHash(readU32, hash) {
+        for (var i = 0x0c; i < buf.length - 4; i += 8)
+            if (readU32(i) === hash) return i;
+        return -1;
+    }
+
+    // Detect endianness via KOROK_SEED_COUNTER
+    var r, le;
+    var beReaders = makeReaders(false);
+    var leReaders = makeReaders(true);
+    if (searchHash(beReaders.u32, 0x8a94e07a) >= 0) { r = beReaders; le = false; }
+    else if (searchHash(leReaders.u32, 0x8a94e07a) >= 0) { r = leReaders; le = true; }
+    else return { error: 'KOROK_SEED_COUNTER not found — not a valid BotW save' };
+
+    var metrics = { console: le ? 'Switch' : 'Wii U' };
+
+    var targets = {
+        KOROK_SEED_COUNTER: { hash: 0x8a94e07a, type: 'u32' },
+        MAX_HEARTS:          { hash: 0x2906f327, type: 'u32' },  // quarter-heart units
+        MAX_STAMINA:         { hash: 0x3adff047, type: 'f32' },
+        PLAYTIME:            { hash: 0x73c29681, type: 'u32' },
+        RUPEES:              { hash: 0x23149bf8, type: 'u32' },
+        MOTORCYCLE:          { hash: 0xc9328299, type: 'u32' },
+        PLAYER_POSITION:     { hash: 0xa40ba103, type: 'f32x3' },
+    };
+
+    for (var name in targets) {
+        var t = targets[name];
+        var off = searchHash(r.u32, t.hash);
+        if (off < 0) { metrics[name] = null; continue; }
+        if (t.type === 'u32') {
+            metrics[name] = r.u32(off + 4);
+        } else if (t.type === 'f32') {
+            metrics[name] = r.f32(off + 4);
+        } else if (t.type === 'f32x3') {
+            // Three consecutive [hash,value] pairs with the same hash: X at +4, Y(height) at +12, Z at +20
+            metrics[name] = {
+                x:       r.f32(off + 4),
+                y:       r.f32(off + 12),
+                z:       r.f32(off + 20),
+                raw_hex: buf.slice(off, off + 24).toString('hex'),
+            };
+        }
+    }
+
+    // Hearts stored as quarter-heart units (÷4 = displayed heart count)
+    if (metrics.MAX_HEARTS != null)
+        metrics.MAX_HEARTS_display = metrics.MAX_HEARTS / 4;
+    // Stamina stored as F32 in units of 1/1000 wheel
+    if (metrics.MAX_STAMINA != null)
+        metrics.MAX_STAMINA_display = +(metrics.MAX_STAMINA / 1000).toFixed(1);
+
+    if (metrics.PLAYTIME != null) {
+        var s = metrics.PLAYTIME;
+        var h = Math.floor(s / 3600), m = Math.floor((s % 3600) / 60), sec = s % 60;
+        metrics.PLAYTIME_formatted = h + ':' + (m<10?'0'+m:m) + ':' + (sec<10?'0'+sec:sec);
+    }
+
+    // Location flag scans — mirror the sidebar metrics
+    try {
+        const map = loadMapHashes();
+        metrics.locations         = scanFlags(buf, r.u32, map.locations);
+        metrics.locations.total   = 226; // hardcoded per game sources (matches sidebar)
+        metrics.shrines_discovered = scanFlags(buf, r.u32, map.shrines);
+        metrics.shrines_completed  = scanFlags(buf, r.u32, map.shrineCompletions);
+        metrics.towers             = scanFlags(buf, r.u32, map.towers);
+        metrics.divine_beasts      = scanFlags(buf, r.u32, map.divineBeasts);
+        metrics.koroks_discovered  = scanFlags(buf, r.u32, map.koroks);
+    } catch (e) {
+        metrics.location_scan_error = e.message;
+    }
+
+    return metrics;
+}
+
+app.get('/api', (req, res) => {
+    const filePath = path.join(__dirname, DATA_PATH);
+    fs.readFile(filePath, (err, data) => {
+        res.setHeader('Cache-Control', 'no-store');
+        if (err) { res.status(404).json({ error: 'Save file not found' }); return; }
+        res.json(parseSaveMetrics(data));
+    });
+});
+
 app.listen(PORT, '0.0.0.0', () => {
     console.log(`Server running at http://localhost:${PORT}`);
 });


### PR DESCRIPTION
## Summary

- **Player Position map marker** — glowing white circle on the map at your character's last saved location; toggle/highlight behavior matches existing metric labels; correctly reads all three coordinate axes from consecutive save entries (X at +4, Y/height at +12, Z/north-south at +20)
- **Player Stats sidebar section** — new section separated by double grey lines containing Hearts (÷4 from quarter-heart units), Stamina (÷1000 from wheel units), Playtime (H:MM:SS), Rupees (locale-formatted), and Motorcycle Owned (red/green indicator)
- **Debug API** — `GET /api` parses the save file server-side and returns all sidebar metrics as JSON including raw/display values, player XYZ, and found/total counts for all location categories
- **Save file compatibility** — added v1.5* and v1.8 game versions; modded saves with non-standard file sizes now accepted
- **Header** — title centered across full viewport width; author byline right-justified
- **Sidebar polish** — Icon Shapes, Player Stats, and Last Updated section titles unified to 11px Cinzel bold uppercase; double grey line separator added between Icon Shapes and Last Updated

## Test plan

- [ ] Sidebar shows Hearts=16, Stamina=3.0, correct Playtime and Rupees after save load
- [ ] Motorcycle light red (not owned) or green (owned) matches save state
- [ ] Player position marker appears on map near expected location; toggling the Player Pos label hides/shows it; hovering highlights it
- [ ] `GET /api` returns plausible JSON with `MAX_HEARTS_display: 16`, `MAX_STAMINA_display: 3`, correct position X/Y/Z, and found/total counts matching sidebar
- [ ] Title centered across full width of browser window; authors right-aligned

🤖 Generated with [Claude Code](https://claude.com/claude-code)