### PR TITLE
Fix hover tooltip overlap and shrine interior player position

### DIFF
--- a/assets/css/zelda-botw.css
+++ b/assets/css/zelda-botw.css
@@ -991,8 +991,11 @@ button.no-text.with-icon:before{margin-right:0px}
 
 #map-container .waypoint:hover:after {
 	content: attr(data-display_name);
-	display: inline-block;
-	position: relative;
+	display: block;
+	position: absolute;
+	left: 14px;
+	top: 50%;
+	transform: translateY(-50%);
 	background: inherit;
 	border: inherit;
 	width: auto;
@@ -1011,8 +1014,8 @@ button.no-text.with-icon:before{margin-right:0px}
 #map-container .waypoint.tower:hover:after,
 #map-container .waypoint.divine-beast:hover:after,
 #map-container .waypoint.warp:hover:after {
-	transform: rotate(-45deg);
-	transform-origin: 0;
+	transform: translateY(-50%) rotate(-45deg);
+	transform-origin: left center;
 }
 
 #map-container .waypoint.highlighted {

--- a/assets/js/zelda-botw.js
+++ b/assets/js/zelda-botw.js
@@ -172,7 +172,16 @@ SavegameEditor={
 			var playerX = tempFile.readF32(_pos + 4);  // first  pair value = X (east/west)
 			// _pos+8 = second hash, _pos+12 = Y (height) — skip
 			var playerZ = tempFile.readF32(_pos + 20); // third pair value = Z (north/south)
-			if (!isNaN(playerX) && !isNaN(playerZ)) placePlayerMarker(playerX, playerZ);
+			if (!isNaN(playerX) && !isNaN(playerZ)) {
+				// When inside a shrine, position values are local interior coords.
+				// Detect via MAP string and substitute the shrine's overworld coordinates.
+				var _shrineCoords = getShrineOverworldCoords();
+				if (_shrineCoords) {
+					placePlayerMarker(_shrineCoords.x, _shrineCoords.y);
+				} else {
+					placePlayerMarker(playerX, playerZ);
+				}
+			}
 		}
 
 		// Player stats — each searched independently
@@ -596,6 +605,42 @@ function placePlayerMarker(x, z) {
 	marker.style.top  = (2500 + z / 2) + 'px';
 	marker.setAttribute('data-display_name', 'Player');
 	map.appendChild(marker);
+}
+
+// Search for a hash at stride 4 (used for string-type save entries not at 8-byte stride)
+function searchHashStride4(hash) {
+	for (var i = 0x0c; i < tempFile.fileSize - 4; i += 4)
+		if (hash === tempFile.readU32(i)) return i;
+	return -1;
+}
+
+// If the player is inside a shrine interior, return the shrine's overworld {x, y} coords.
+// MAPTYPE hash (0xd913b769) stores the current map name fragmented across consecutive
+// [hash, 4-byte-chunk] pairs — e.g. "CDun"+"geon"+"/Dun"+"geon"+"068\0" = "CDungeon/Dungeon068".
+// Returns null if overworld or hash not found.
+function getShrineOverworldCoords() {
+	var HASH = 0xd913b769;
+	var off = searchHashStride4(HASH);
+	if (off < 0) return null;
+	// Collect 4-byte chunks from consecutive [hash, value] pairs
+	var mapName = '';
+	var done = false;
+	while (!done && off + 8 <= tempFile.fileSize && tempFile.readU32(off) === HASH) {
+		for (var b = 0; b < 4; b++) {
+			var c = tempFile.readU8(off + 4 + b);
+			if (c === 0) { done = true; break; }
+			mapName += String.fromCharCode(c);
+		}
+		off += 8;
+	}
+	var m = /^CDungeon\/Dungeon(\d+)/.exec(mapName);
+	if (!m) return null;
+	var target = 'Location_Dungeon' + m[1];
+	for (var warpHash in warps) {
+		if (warps[warpHash].internal_name === target)
+			return { x: warps[warpHash].x, y: warps[warpHash].y };
+	}
+	return null;
 }
 
 function formatPlaytime(seconds) {

--- a/server/server.js
+++ b/server/server.js
@@ -122,6 +122,8 @@ function parseSaveMetrics(buf) {
         RUPEES:              { hash: 0x23149bf8, type: 'u32' },
         MOTORCYCLE:          { hash: 0xc9328299, type: 'u32' },
         PLAYER_POSITION:     { hash: 0xa40ba103, type: 'f32x3' },
+        MAP:                 { hash: 0x0bee9e46, type: 'u32' },
+        MAPTYPE:             { hash: 0xd913b769, type: 'u32' },
     };
 
     for (var name in targets) {


### PR DESCRIPTION
## Summary
- Map icon hover labels now render offset 14px to the right of the icon so the dot/diamond is no longer obscured
- When inside a shrine, the player position marker is placed at the shrine's overworld map location instead of the local interior coordinates
- Shrine detection reads the MAPTYPE save flag (fragmented ASCII string across consecutive hash+value pairs), parses the dungeon number, and looks up the shrine's overworld coordinates in the warps table

## Test plan
- [ ] Hover over any map icon — label should appear clearly to the right, not on top of the dot/diamond
- [ ] Load save while inside a shrine — player marker should appear at the shrine entrance on the overworld map, not near map center
- [ ] Load save in the overworld — player marker should appear at the correct overworld coordinates as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)