### PR TITLE
Improve map pin hover labels: zoom-aware, JS tooltip, shrine label

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Map icons use shape and color to indicate type:
 - **Diamonds** — Shrines discovered (cyan), Shrines completed (yellow), Towers (violet), Divine Beasts (red), and other Warp Points
 - **Glowing circle** — Player position (white)
 
-Hovering over any map icon shows its name label offset to the side so the marker itself remains visible.
+Hovering over any map icon shows a floating label offset to the side of the pin. Labels are zoom-aware — they scale up when zoomed out to stay readable, and maintain a consistent gap from the pin at all zoom levels. Labels use a semi-transparent dark style so the map remains visible behind them. When the player is inside a shrine, the player marker label reads **Player (In Shrine)**.
 
 A server status indicator and save file timestamp at the bottom of the sidebar show server reachability and when your save was last read.
 

--- a/assets/css/zelda-botw.css
+++ b/assets/css/zelda-botw.css
@@ -989,33 +989,23 @@ button.no-text.with-icon:before{margin-right:0px}
 	cursor: pointer;
 }
 
-#map-container .waypoint:hover:after {
-	content: attr(data-display_name);
-	display: block;
+/* JS-positioned tooltip — sibling of waypoints in map-container, no rotation inheritance */
+#waypoint-tooltip {
+	display: none;
 	position: absolute;
-	left: 14px;
-	top: 50%;
+	pointer-events: none;
 	transform: translateY(-50%);
-	background: inherit;
-	border: inherit;
-	width: auto;
-	height: auto;
+	background: rgba(15, 20, 30, 0.62);
+	color: #e8eaf0;
+	border: 1px solid rgba(160, 180, 210, 0.45);
 	font-family: 'Noto Sans', sans-serif;
-	font-size: 11px;
-	font-weight: 500;
-	z-index: 1000;
-	border-radius: 0%;
+	font-size: max(11px, calc(10px / var(--map-scale, 1)));
+	font-weight: 600;
+	border-radius: calc(5px / var(--map-scale, 1));
 	white-space: nowrap;
-	padding: 0px 4px;
-}
-
-#map-container .waypoint.shrine:hover:after,
-#map-container .waypoint.shrine-completed:hover:after,
-#map-container .waypoint.tower:hover:after,
-#map-container .waypoint.divine-beast:hover:after,
-#map-container .waypoint.warp:hover:after {
-	transform: translateY(-50%) rotate(-45deg);
-	transform-origin: left center;
+	padding: calc(3px / var(--map-scale, 1)) calc(8px / var(--map-scale, 1));
+	box-shadow: 0 calc(2px / var(--map-scale, 1)) calc(8px / var(--map-scale, 1)) rgba(0,0,0,0.6);
+	z-index: 1000;
 }
 
 #map-container .waypoint.highlighted {

--- a/assets/js/zelda-botw.js
+++ b/assets/js/zelda-botw.js
@@ -177,7 +177,7 @@ SavegameEditor={
 				// Detect via MAP string and substitute the shrine's overworld coordinates.
 				var _shrineCoords = getShrineOverworldCoords();
 				if (_shrineCoords) {
-					placePlayerMarker(_shrineCoords.x, _shrineCoords.y);
+					placePlayerMarker(_shrineCoords.x, _shrineCoords.y, 'Player (In Shrine)');
 				} else {
 					placePlayerMarker(playerX, playerZ);
 				}
@@ -544,12 +544,62 @@ function applyHiddenStates() {
 // Add event Listeners for Waypoints
 function addWaypointListeners() {
 
-	[].forEach.call( document.querySelectorAll( '.waypoint:not(.warp)' ), function( element ) {
-		element.addEventListener( 'click', function() {
-			removeWaypoint( element );
-		} );
+	[].forEach.call( document.querySelectorAll( '.waypoint' ), function( element ) {
+		if ( !element.classList.contains( 'warp' ) ) {
+			element.addEventListener( 'click', function() {
+				removeWaypoint( element );
+			} );
+		}
+		element.addEventListener( 'mouseenter', function() { showWaypointTooltip( element ); } );
+		element.addEventListener( 'mouseleave', hideWaypointTooltip );
 	} );
 
+}
+
+var _waypointTooltip = null;
+
+function showWaypointTooltip( waypoint ) {
+	var name = waypoint.getAttribute( 'data-display_name' );
+	if ( !name ) return;
+
+	if ( !_waypointTooltip ) {
+		_waypointTooltip = document.createElement( 'div' );
+		_waypointTooltip.id = 'waypoint-tooltip';
+		document.getElementById( 'map-container' ).appendChild( _waypointTooltip );
+	}
+
+	// Waypoint left/top are the map-coordinate anchor point.
+	// Circles: transform: translate(-5px,-5px) — visual center is at (left, top)
+	// Diamonds: transform: translate(-2px,0) rotate(45deg) around top-right —
+	//   rightmost visual tip is at approx (left+8.6, top-1.4) in map coords.
+	var L = parseFloat( waypoint.style.left ) || 0;
+	var T = parseFloat( waypoint.style.top )  || 0;
+	var isDiamond = waypoint.classList.contains( 'shrine' ) ||
+	                waypoint.classList.contains( 'shrine-completed' ) ||
+	                waypoint.classList.contains( 'tower' ) ||
+	                waypoint.classList.contains( 'divine-beast' ) ||
+	                waypoint.classList.contains( 'warp' );
+
+	var scale = parseFloat( getComputedStyle( document.documentElement ).getPropertyValue( '--map-scale' ) ) || 1;
+	var GAP = 10 / scale; // constant 10px gap in screen space, expressed in map coords
+
+	var tx, ty;
+	if ( isDiamond ) {
+		tx = L + 8.6 + GAP;  // start from right tip of diamond
+		ty = T - 1.4;         // visual center y of diamond
+	} else {
+		tx = L + 5 + GAP;    // start from right edge of circle (radius 5)
+		ty = T;               // visual center y of circle
+	}
+
+	_waypointTooltip.textContent = name;
+	_waypointTooltip.style.left = tx + 'px';
+	_waypointTooltip.style.top  = ty + 'px';
+	_waypointTooltip.style.display = 'block';
+}
+
+function hideWaypointTooltip() {
+	if ( _waypointTooltip ) _waypointTooltip.style.display = 'none';
 }
 
 // Remove an individual Waypoint and save that change in localStorage
@@ -588,13 +638,14 @@ function removeWaypoint( element ) {
 // Remove all Waypoints
 function removeAllWaypoints() {
 
+	hideWaypointTooltip();
 	[].forEach.call( document.querySelectorAll( '.waypoint, .line' ), function( element ) {
 		element.remove();
 	} );
 
 }
 
-function placePlayerMarker(x, z) {
+function placePlayerMarker(x, z, label) {
 	var map = document.getElementById('map-container');
 	var existing = document.getElementById('player-position-marker');
 	if (existing) existing.remove();
@@ -603,7 +654,7 @@ function placePlayerMarker(x, z) {
 	marker.classList.add('waypoint', 'player-position');
 	marker.style.left = (3000 + x / 2) + 'px';
 	marker.style.top  = (2500 + z / 2) + 'px';
-	marker.setAttribute('data-display_name', 'Player');
+	marker.setAttribute('data-display_name', label || 'Player');
 	map.appendChild(marker);
 }
 
@@ -690,6 +741,7 @@ function setMotorcycleIndicator(owned) {
 		scale = minZoom;
 		panX = 0;
 		panY = 0;
+		document.documentElement.style.setProperty('--map-scale', scale);
 		updateTransform();
 
 		// Mouse wheel for zoom
@@ -779,6 +831,7 @@ function setMotorcycleIndicator(owned) {
 		panY = Math.min(maxPanY, Math.max(minPanY, panY));
 
 		mapContainer.style.transform = 'translate(' + panX + 'px, ' + panY + 'px) scale(' + scale + ')';
+		document.documentElement.style.setProperty('--map-scale', scale);
 	}
 
 	// Initialize when DOM is ready


### PR DESCRIPTION
## Summary
- Replaced CSS `::after` label approach with a JS-positioned tooltip `<div>` sibling in `map-container`, fixing rotation inheritance issues that caused diamond pin labels (shrines, towers, etc.) to be misaligned
- Tooltip gap from pin is now a constant 10px on screen at all zoom levels
- Font size, padding, border-radius, and box-shadow all counter-scale with `--map-scale` so labels stay readable when zoomed out
- Semi-transparent dark background (62% opacity) keeps the map visible behind labels
- Player marker label shows **"Player (In Shrine)"** when the save was made inside a shrine

## Test plan
- [ ] Hover over circle pins (koroks, locations) — label appears cleanly to the right at all zoom levels
- [ ] Hover over diamond pins (shrines, towers, divine beasts) — label is vertically aligned and offset correctly at all zoom levels
- [ ] Zoom fully out and in — label font and gap remain readable and consistent
- [ ] Load a save made inside a shrine — player marker shows "Player (In Shrine)"

🤖 Generated with [Claude Code](https://claude.com/claude-code)