### PR TITLE
chore: bump version to 1.6.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botw-live-savegame-monitor",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "A browser-based interactive map overlay for *The Legend of Zelda: Breath of the Wild* (Cemu emulator). It reads your Cemu save files directly — no mods, no plugins — and renders your completion progress on a pannable, zoomable map in real time. Korok seeds, locations, shrines, towers, divine beasts, and your current player position are all shown as color-coded icons that update automatically whenever you save in-game (manual or auto-save). Runs as a Docker container on the same machine as Cemu and is accessible from any browser on your local network.",
   "main": "electron/main.js",
   "scripts": {


### PR DESCRIPTION
## Summary
- Bump patch version to 1.6.1 to unblock release CI (v1.6.0 tag already existed)

## Test plan
- [ ] CI builds Windows exe on master push
- [ ] GitHub Release created as v1.6.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)
