### PR TITLE
Fix duplicate desktop shortcut on NSIS reinstall

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -178,7 +178,12 @@ function wipeAppData() {
 
 function createDesktopShortcut() {
     if (!app.isPackaged) return;
-    const exePath = process.env.PORTABLE_EXECUTABLE_FILE || process.execPath;
+    // Only manage the desktop shortcut for the portable exe.
+    // The NSIS installer creates and manages its own shortcut; running this for
+    // an NSIS build causes a duplicate icon when the installer and app both write
+    // to different desktop locations (Public vs User desktop).
+    if (!process.env.PORTABLE_EXECUTABLE_FILE) return;
+    const exePath = process.env.PORTABLE_EXECUTABLE_FILE;
     const ps = [
         `$ws = New-Object -ComObject WScript.Shell`,
         `$s = $ws.CreateShortcut([Environment]::GetFolderPath('Desktop') + '\\BotW Live Savegame Monitor.lnk')`,


### PR DESCRIPTION
Closes BACK-005.

**Root cause:** `createDesktopShortcut()` ran for both NSIS and portable builds. When the NSIS installer runs as admin, it places its shortcut on the Public Desktop (`C:\Users\Public\Desktop`). The app then writes a second shortcut to the User Desktop via PowerShell's `[Environment]::GetFolderPath('Desktop')` — two separate `.lnk` files, both visible.

**Fix:** Guard `createDesktopShortcut()` to only execute when `PORTABLE_EXECUTABLE_FILE` is set, which Electron only sets for portable builds. NSIS exclusively manages its own shortcut for the installer build.