### PR TITLE
fix: set artifactName to fix update download URL mismatch (v1.6.8)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botw-live-savegame-monitor",
-  "version": "1.6.7",
+  "version": "1.6.8",
   "description": "A browser-based interactive map overlay for *The Legend of Zelda: Breath of the Wild* (Cemu emulator). It reads your Cemu save files directly — no mods, no plugins — and renders your completion progress on a pannable, zoomable map in real time. Korok seeds, locations, shrines, towers, divine beasts, and your current player position are all shown as color-coded icons that update automatically whenever you save in-game (manual or auto-save). Runs as a Docker container on the same machine as Cemu and is accessible from any browser on your local network.",
   "main": "electron/main.js",
   "scripts": {
@@ -35,7 +35,8 @@
       "target": [
         { "target": "nsis", "arch": ["x64"] }
       ],
-      "icon": "favicon.ico"
+      "icon": "favicon.ico",
+      "artifactName": "BotW-Live-Savegame-Monitor-Setup-${version}.${ext}"
     },
     "nsis": {
       "oneClick": false,


### PR DESCRIPTION
## Root Cause

electron-updater was silently 404ing on every download attempt because the filename in latest.yml didn't match the actual GitHub release asset name.

- electron-builder normalises spaces in productName to hyphens in the latest.yml URL
- GitHub's asset API converts spaces in uploaded filenames to dots
- Result: latest.yml referenced BotW-Live-Savegame-Monitor-Setup-X.Y.Z.exe but the asset was BotW.Live.Savegame.Monitor.Setup.X.Y.Z.exe

## Fix

Added artifactName to the win build config so electron-builder generates the installer with hyphens — no spaces, no conversion ambiguity, latest.yml and the release asset always match.

## Testing

Install v1.6.7, launch v1.6.8 — update dialog should appear, Install Now should download and install correctly.