### PR TITLE
fix(installer): skip shortcut deletion during update (BACK-008)

### DIFF
--- a/electron/installer.nsh
+++ b/electron/installer.nsh
@@ -11,6 +11,8 @@
 !macroend
 
 !macro customUnInstall
-    Delete "$DESKTOP\BotW Live Savegame Monitor.lnk"
-    Delete "$SMPROGRAMS\BotW Live Savegame Monitor.lnk"
+    ${ifNot} ${isUpdated}
+        Delete "$DESKTOP\BotW Live Savegame Monitor.lnk"
+        Delete "$SMPROGRAMS\BotW Live Savegame Monitor.lnk"
+    ${endIf}
 !macroend


### PR DESCRIPTION
## Summary

- `customUnInstall` was unconditionally deleting the desktop and Start Menu shortcuts before `customInstall` ran during auto-updates
- This defeated the `IfFileExists` guard added in ce5c46e — the shortcut was always gone by the time the guard checked
- Root cause: NSIS runs the old uninstaller *before* the new installer on update; our macro had no awareness of this context

## Fix

Wrap the `Delete` calls in `customUnInstall` with `${ifNot} ${isUpdated}` so shortcuts are only removed during a full uninstall, not during an upgrade. `${isUpdated}` is a LogicLib predicate injected by electron-builder that tests for the `--updated` CLI flag passed during auto-updates.

## Test Plan
- [ ] Build new installer with `botw-build-windows-exe` skill
- [ ] Install over existing version via auto-update
- [ ] Verify desktop shortcut is NOT deleted/recreated during update
- [ ] Verify desktop shortcut IS removed on full uninstall

Closes #55