### PR TITLE
Release v1.6.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botw-live-savegame-monitor",
-  "version": "1.6.11",
+  "version": "1.6.12",
   "description": "A browser-based interactive map overlay for *The Legend of Zelda: Breath of the Wild* (Cemu emulator). It reads your Cemu save files directly — no mods, no plugins — and renders your completion progress on a pannable, zoomable map in real time. Korok seeds, locations, shrines, towers, divine beasts, and your current player position are all shown as color-coded icons that update automatically whenever you save in-game (manual or auto-save). Runs as a Docker container on the same machine as Cemu and is accessible from any browser on your local network.",
   "main": "electron/main.js",
   "scripts": {


### PR DESCRIPTION
## Summary
- Bumps version to 1.6.12
- Includes fix: skip shortcut deletion during update (BACK-008, #55)

🤖 Generated with [Claude Code](https://claude.com/claude-code)